### PR TITLE
Edit /etc/modules in "install" function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all:
 install:
 	mkdir -p /lib/modules/$(KVERSION)/extra
 	cp intrepid.ko /lib/modules/$(KVERSION)/extra/
+	grep -q -F 'intrepid' /etc/modules || echo 'intrepid' | tee -a /etc/modules
 	depmod -a
 clean:
 	make -C /lib/modules/$(KVERSION)/build M=$(PWD) clean


### PR DESCRIPTION
The previous version of the "install" function in the MakeFile didn't update the /etc/modules file to include intrepid as a kernel to load at boot time. This change makes the necessary change, allowing the kernel to be loaded automatically.