### PR TITLE
Fix for newer 6.4.x Kernel, class_create() sig changed

### DIFF
--- a/intrepid.c
+++ b/intrepid.c
@@ -1156,7 +1156,11 @@ static __init int intrepid_init(void)
 		return -1;
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	intrepid_dev_class = class_create(THIS_MODULE, INTREPID_CLASS_NAME);
+#else
+	intrepid_dev_class = class_create(INTREPID_CLASS_NAME);
+#endif
 	if (IS_ERR(intrepid_dev_class)) {
 		ret = PTR_ERR(intrepid_dev_class);
 		pr_alert("intrepid: failed to create device class, got %d\n", ret);


### PR DESCRIPTION
Fixes Issue #15 

Adds conditional for newer Kernel versions to use the new class_create() intreface